### PR TITLE
feat: Add fixed EPUB chapter extraction to handle subchapters correctly

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,6 +24,11 @@ python -m pytest $TEST_DIR/test_basic.py -v
 BASIC_RESULT=$?
 
 echo ""
+echo "🧪 运行 EPUB 章节提取修复版本测试..."
+python -m pytest $TEST_DIR/test_epub_chapter_extraction_fixed.py -v
+FIXED_RESULT=$?
+
+echo ""
 echo "🧪 运行 AZW 测试（如果模块可用）..."
 python -m pytest $TEST_DIR/test_azw.py -v
 AZW_RESULT=$?
@@ -39,6 +44,12 @@ else
     echo "❌ 基本测试: 失败"
 fi
 
+if [ $FIXED_RESULT -eq 0 ]; then
+    echo "✅ EPUB 章节提取修复测试: 通过"
+else
+    echo "❌ EPUB 章节提取修复测试: 失败"
+fi
+
 if [ $AZW_RESULT -eq 0 ]; then
     echo "✅ AZW 测试: 通过或跳过"
 else
@@ -52,7 +63,7 @@ echo "   - 查看详细测试指南: cat HOW-TO-TEST.md"
 echo ""
 
 # 返回总体结果
-if [ $BASIC_RESULT -eq 0 ] && [ $AZW_RESULT -eq 0 ]; then
+if [ $BASIC_RESULT -eq 0 ] && [ $FIXED_RESULT -eq 0 ] && [ $AZW_RESULT -eq 0 ]; then
     echo "🎉 所有可用测试通过！"
     exit 0
 else

--- a/src/ebook_mcp/main.py
+++ b/src/ebook_mcp/main.py
@@ -100,6 +100,32 @@ def get_epub_chapter_markdown(epub_path:str, chapter_id: str) -> str:
     except Exception as e:
         raise Exception(str(e))
 
+@mcp.tool()
+def get_epub_chapter_markdown_fixed(epub_path:str, chapter_id: str) -> str:
+    """Get content of a given chapter using the fixed extraction method.
+    
+    This function uses extract_chapter_html_fixed which properly handles subchapters
+    and provides accurate chapter boundaries, fixing the issue where subchapters
+    in the TOC cause premature truncation of chapter content.
+
+    Args:
+        epub_path: Full path to the ebook file. eg. "/Users/macbook/Downloads/test.epub"
+        chapter_id: Chapter id of the chapter to get content (e.g., "chapter1.xhtml#section1_3")
+    
+    Returns:
+        str: Chapter content in markdown format
+    """
+    logger.debug(f"calling get_epub_chapter_markdown_fixed: {epub_path}, chapter ID: {chapter_id}")
+    try:
+        book = epub_helper.read_epub(epub_path)
+        
+        # Use the fixed version instead of the original
+        return epub_helper.extract_chapter_markdown_fixed(book, chapter_id)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(str(e))
+    except Exception as e:
+        raise Exception(str(e))
+
 # PDF related tools
 @mcp.tool()
 def get_all_pdf_files(path: str) -> List[str]:

--- a/src/ebook_mcp/main.py
+++ b/src/ebook_mcp/main.py
@@ -83,9 +83,14 @@ def get_epub_toc(epub_path: str) -> List[Tuple[str, str]]:
     except Exception as e:
         raise Exception(str(e))
 
-@mcp.tool()
+@mcp.tool(deprecated=True)
 def get_epub_chapter_markdown(epub_path:str, chapter_id: str) -> str:
     """Get content of a given chapter of a given ebook.
+    
+    ⚠️ DEPRECATED: This tool has a known issue when processing EPUB files with subchapters.
+    When the TOC contains subchapters, it may prematurely truncate chapter content and only return the chapter title.
+    
+    It is recommended to use get_epub_chapter_markdown_fixed for more accurate chapter extraction results.
 
     Args:
         epub_path: Full path to the ebook file.eg. "/Users/macbook/Downloads/test.epub"
@@ -102,7 +107,10 @@ def get_epub_chapter_markdown(epub_path:str, chapter_id: str) -> str:
 
 @mcp.tool()
 def get_epub_chapter_markdown_fixed(epub_path:str, chapter_id: str) -> str:
-    """Get content of a given chapter using the fixed extraction method.
+    """Get content of a given chapter using the improved extraction method.
+    
+    ✅ RECOMMENDED: This tool fixes the truncation issue in the original version when processing subchapters.
+    It can correctly handle EPUB files with subchapters and provide complete chapter content.
     
     This function uses extract_chapter_html_fixed which properly handles subchapters
     and provides accurate chapter boundaries, fixing the issue where subchapters

--- a/src/ebook_mcp/tests/test_epub_chapter_extraction_fixed.py
+++ b/src/ebook_mcp/tests/test_epub_chapter_extraction_fixed.py
@@ -1,0 +1,370 @@
+import pytest
+import tempfile
+import os
+from unittest.mock import Mock, patch, MagicMock
+
+# Mock external dependencies
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+# Mock ebooklib
+try:
+    from ebooklib import epub
+except ImportError:
+    epub = Mock()
+
+# Mock BeautifulSoup
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    BeautifulSoup = Mock()
+
+from ebook_mcp.tools.epub_helper import (
+    extract_chapter_html_fixed,
+    extract_chapter_html,  # 原函数用于对比
+    extract_chapter_markdown_fixed,
+    extract_chapter_markdown,  # 原函数用于对比
+    clean_html,
+    convert_html_to_markdown
+)
+
+
+class TestExtractChapterHtmlFixed:
+    """Test the fixed version of extract_chapter_html function"""
+    
+    def test_simple_chapter_extraction(self):
+        """Test simple chapter extraction without subchapters"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock TOC structure
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_chapter2 = Mock()
+        mock_chapter2.title = "Chapter 2"
+        mock_chapter2.href = "chapter2.xhtml"
+        
+        mock_book.toc = [mock_chapter1, mock_chapter2]
+        
+        # Mock HTML content
+        html_content = """
+        <html>
+            <body>
+                <h1 id="chapter1">Chapter 1</h1>
+                <p>Chapter 1 content</p>
+                
+                <h1 id="chapter2">Chapter 2</h1>
+                <p>Chapter 2 content</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test extracting Chapter 1
+        result = extract_chapter_html_fixed(mock_book, "chapter1.xhtml")
+        
+        # Should include Chapter 1 content but not Chapter 2
+        assert "Chapter 1 content" in result
+        assert "Chapter 2 content" not in result
+    
+    def test_chapter_with_subchapters_bug_case(self):
+        """Test the specific bug case: chapter with subchapters causing premature truncation"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock TOC structure with subchapters (the problematic case)
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_subchapter1_3 = Mock()
+        mock_subchapter1_3.title = "1.3 Append-only"
+        mock_subchapter1_3.href = "chapter1.xhtml#section1_3"
+        
+        mock_subchapter1_4 = Mock()
+        mock_subchapter1_4.title = "1.4 Another Section"
+        mock_subchapter1_4.href = "chapter1.xhtml#section1_4"
+        
+        mock_chapter2 = Mock()
+        mock_chapter2.title = "Chapter 2"
+        mock_chapter2.href = "chapter2.xhtml"
+        
+        # Set up nested TOC
+        mock_book.toc = [
+            (mock_chapter1, [mock_subchapter1_3, mock_subchapter1_4]),
+            mock_chapter2
+        ]
+        
+        # Mock HTML content that matches the bug report
+        html_content = """
+        <html>
+            <body>
+                <h1 id="chapter1">Chapter 1</h1>
+                <p>Chapter 1 introduction</p>
+                
+                <h2 id="section1_3">1.3 Append-only</h2>
+                <h3 id="subsection">Safe incremental updates with logs</h3>
+                <p>One way to do incremental updates is to just append the updates to a file. 
+                This is called a "log" because it's append-only. It's safer than in-place updates 
+                because no data is overwritten; you can always recover the old data after a crash.</p>
+                
+                <h2 id="section1_4">1.4 Another Section</h2>
+                <p>Another section content</p>
+                
+                <h1 id="chapter2">Chapter 2</h1>
+                <p>Chapter 2 content</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test extracting section1_3 (the problematic case)
+        result = extract_chapter_html_fixed(mock_book, "chapter1.xhtml#section1_3")
+        
+        # Should include the full section content
+        assert "1.3 Append-only" in result
+        assert "Safe incremental updates with logs" in result
+        assert "One way to do incremental updates" in result
+        assert "This is called a \"log\" because it's append-only" in result
+        
+        # Should NOT include content from other sections
+        assert "1.4 Another Section" not in result
+        assert "Another section content" not in result
+        assert "Chapter 2 content" not in result
+    
+    def test_comparison_with_original_function(self):
+        """Compare the fixed function with the original function"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock TOC structure
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_subchapter1_3 = Mock()
+        mock_subchapter1_3.title = "1.3 Append-only"
+        mock_subchapter1_3.href = "chapter1.xhtml#section1_3"
+        
+        mock_subchapter1_4 = Mock()
+        mock_subchapter1_4.title = "1.4 Another Section"
+        mock_subchapter1_4.href = "chapter1.xhtml#section1_4"
+        
+        mock_book.toc = [
+            (mock_chapter1, [mock_subchapter1_3, mock_subchapter1_4])
+        ]
+        
+        # Mock HTML content
+        html_content = """
+        <html>
+            <body>
+                <h2 id="section1_3">1.3 Append-only</h2>
+                <p>Section 1.3 content</p>
+                
+                <h2 id="section1_4">1.4 Another Section</h2>
+                <p>Section 1.4 content</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test with original function (should fail - only return title)
+        original_result = extract_chapter_html(mock_book, "chapter1.xhtml#section1_3")
+        
+        # Test with fixed function (should work - return full content)
+        fixed_result = extract_chapter_html_fixed(mock_book, "chapter1.xhtml#section1_3")
+        
+        # Both functions should return the same content in this case
+        # The key difference is in the bug case with subchapters
+        assert "Section 1.3 content" in fixed_result
+        assert "Section 1.4 content" not in fixed_result
+    
+    def test_markdown_conversion_fixed(self):
+        """Test the fixed markdown conversion function"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock TOC structure
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_subchapter1_3 = Mock()
+        mock_subchapter1_3.title = "1.3 Append-only"
+        mock_subchapter1_3.href = "chapter1.xhtml#section1_3"
+        
+        mock_book.toc = [
+            (mock_chapter1, [mock_subchapter1_3])
+        ]
+        
+        # Mock HTML content
+        html_content = """
+        <html>
+            <body>
+                <h2 id="section1_3">1.3 Append-only</h2>
+                <p>This is <strong>bold</strong> content.</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test markdown conversion
+        result = extract_chapter_markdown_fixed(mock_book, "chapter1.xhtml#section1_3")
+        
+        # Should convert to markdown format
+        assert "1.3 Append-only" in result
+        assert "bold" in result
+    
+    def test_edge_cases(self):
+        """Test edge cases and error conditions"""
+        # Mock EPUB book
+        mock_book = Mock()
+        mock_book.toc = []
+        
+        # Test with non-existent chapter
+        with pytest.raises(ValueError, match="not found in TOC"):
+            extract_chapter_html_fixed(mock_book, "nonexistent.xhtml")
+        
+        # Test with non-existent anchor
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        mock_book.toc = [mock_chapter1]
+        
+        mock_item = Mock()
+        mock_item.get_content.return_value = "<html><body><h1>Test</h1></body></html>".encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        with pytest.raises(ValueError, match="not found in TOC"):
+            extract_chapter_html_fixed(mock_book, "chapter1.xhtml#nonexistent")
+    
+    def test_last_chapter_extraction(self):
+        """Test extracting the last chapter (no next chapter)"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock TOC structure
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_chapter2 = Mock()
+        mock_chapter2.title = "Chapter 2"
+        mock_chapter2.href = "chapter2.xhtml"
+        
+        mock_book.toc = [mock_chapter1, mock_chapter2]
+        
+        # Mock HTML content
+        html_content = """
+        <html>
+            <body>
+                <h1 id="chapter2">Chapter 2</h1>
+                <p>Chapter 2 content</p>
+                <p>More content</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test extracting the last chapter
+        result = extract_chapter_html_fixed(mock_book, "chapter2.xhtml")
+        
+        # Should include all content (no next chapter to truncate at)
+        assert "Chapter 2 content" in result
+        assert "More content" in result
+    
+    def test_complex_nested_toc(self):
+        """Test with complex nested TOC structure"""
+        # Mock EPUB book
+        mock_book = Mock()
+        
+        # Mock complex TOC structure
+        mock_chapter1 = Mock()
+        mock_chapter1.title = "Chapter 1"
+        mock_chapter1.href = "chapter1.xhtml"
+        
+        mock_subchapter1_1 = Mock()
+        mock_subchapter1_1.title = "1.1 Introduction"
+        mock_subchapter1_1.href = "chapter1.xhtml#intro"
+        
+        mock_subchapter1_2 = Mock()
+        mock_subchapter1_2.title = "1.2 Background"
+        mock_subchapter1_2.href = "chapter1.xhtml#background"
+        
+        mock_subchapter1_3 = Mock()
+        mock_subchapter1_3.title = "1.3 Append-only"
+        mock_subchapter1_3.href = "chapter1.xhtml#section1_3"
+        
+        mock_chapter2 = Mock()
+        mock_chapter2.title = "Chapter 2"
+        mock_chapter2.href = "chapter2.xhtml"
+        
+        # Set up nested TOC
+        mock_book.toc = [
+            (mock_chapter1, [mock_subchapter1_1, mock_subchapter1_2, mock_subchapter1_3]),
+            mock_chapter2
+        ]
+        
+        # Mock HTML content
+        html_content = """
+        <html>
+            <body>
+                <h1 id="chapter1">Chapter 1</h1>
+                
+                <h2 id="intro">1.1 Introduction</h2>
+                <p>Introduction content</p>
+                
+                <h2 id="background">1.2 Background</h2>
+                <p>Background content</p>
+                
+                <h2 id="section1_3">1.3 Append-only</h2>
+                <p>Section 1.3 content</p>
+                <p>More content in section 1.3</p>
+                
+                <h1 id="chapter2">Chapter 2</h1>
+                <p>Chapter 2 content</p>
+            </body>
+        </html>
+        """
+        
+        # Mock book.get_item_with_href
+        mock_item = Mock()
+        mock_item.get_content.return_value = html_content.encode('utf-8')
+        mock_book.get_item_with_href.return_value = mock_item
+        
+        # Test extracting section1_3
+        result = extract_chapter_html_fixed(mock_book, "chapter1.xhtml#section1_3")
+        
+        # Should include section 1.3 content
+        assert "1.3 Append-only" in result
+        assert "Section 1.3 content" in result
+        assert "More content in section 1.3" in result
+        
+        # Should NOT include content from other sections
+        assert "1.1 Introduction" not in result
+        assert "Introduction content" not in result
+        assert "1.2 Background" not in result
+        assert "Background content" not in result
+        assert "Chapter 2 content" not in result 


### PR DESCRIPTION
## 简短描述
修复 EPUB 章节提取中的子章节截断问题，新增 `extract_chapter_html_fixed` 函数和相关工具，确保能够正确提取完整的章节内容。

### 问题代码示例
```python
# 原始逻辑的问题
next_href = toc[idx + 1] if idx + 1 < len(toc) else None
# 当 toc[idx + 1] 是子章节时，会导致错误截断
```

## 🔧 解决方案

### 1. 新增修复版本函数
在不修改现有实现的前提下，添加了修复版本的函数：

- `extract_chapter_html_fixed()` - 修复版本的章节 HTML 提取
- `extract_chapter_markdown_fixed()` - 修复版本的 Markdown 转换
- `extract_chapter_plain_text_fixed()` - 修复版本的纯文本提取
- `extract_multiple_chapters_fixed()` - 修复版本的多章节提取

### 2. 核心修复逻辑
```python
def extract_chapter_html_fixed(book, anchor_href):
    # 1. 解析 TOC 层级结构，理解章节层次关系
    toc_entries = []
    for item in book.toc:
        if isinstance(item, tuple):
            chapter = item[0]
            toc_entries.append((chapter.title, chapter.href, 1))  # 主章节
            for sub_item in item[1]:
                toc_entries.append((sub_item.title, sub_item.href, 2))  # 子章节
        else:
            toc_entries.append((item.title, item.href, 1))
    
    # 2. 找到当前章节的层级
    current_level = get_current_chapter_level(toc_entries, anchor_href)
    
    # 3. 找到下一个同级或更高级的章节
    next_chapter_href = find_next_chapter_at_same_or_higher_level(toc_entries, current_idx, current_level)
    
    # 4. 智能截断：只在遇到同级或更高级标题时停止
    def heading_level(tag_name):
        if tag_name and tag_name.startswith('h') and tag_name[1:].isdigit():
            return int(tag_name[1:])
        return 7
    
    start_level = heading_level(start_elem.name)
    for elem in start_elem.next_elements:
        if elem is start_elem:
            elems.append(str(elem))
            continue
        if hasattr(elem, 'name') and elem.name and elem.name.startswith('h') and elem.name[1:].isdigit():
            if heading_level(elem.name) <= start_level:  # 同级或更高级标题
                break
        elems.append(str(elem))
```

## 关键变更
- ✅ 新增修复版本函数，不修改现有实现
- ✅ 智能 TOC 层级分析，正确处理子章节
- ✅ 精确章节边界识别，避免过早截断
- ✅ 完整的测试覆盖（7个测试用例）
- ✅ 新增 MCP 工具 `get_epub_chapter_markdown_fixed`. 
- ✅ 标记老的MCP 工具为 deprecated `get_epub_chapter_markdown`. 
- ✅ 更新测试脚本，包含修复版本测试

## 解决的问题
修复前：获取 "1.3 Append-only" 章节只返回标题
修复后：返回完整的章节内容，包括所有子标题和正文

## 兼容性
- 向后兼容，不影响现有功能
- 渐进式升级，可选择使用新版本

## 测试状态
```
✅ 基本测试: 10 passed
✅ EPUB 章节提取修复测试: 7 passed  
✅ AZW 测试: 4 skipped
```

## 文件变更
- `src/ebook_mcp/tools/epub_helper.py` - 添加修复版本函数
- `src/ebook_mcp/main.py` - 添加新的 MCP 工具
- `src/ebook_mcp/tests/test_epub_chapter_extraction_fixed.py` - 新增测试文件
- `run_tests.sh` - 更新测试脚本 





## 📋 问题描述

在使用 `get_epub_chapter_markdown` 工具获取包含子章节的 EPUB 文件内容时，遇到了章节内容被过早截断的问题。

### 具体问题
- 当 TOC 中包含子章节时，`flatten_toc` 返回的 href 列表包含子章节
- `extract_chapter_html` 使用简单的 `idx + 1` 逻辑找到下一个 href
- 如果下一个 href 是子章节，会导致章节内容被过早截断
- 例如：获取 "1.3 Append-only" 章节时，只返回章节标题，不包含完整内容
