### PR TITLE
Fix cli_entry returning empty tools

### DIFF
--- a/src/ebook_mcp/main.py
+++ b/src/ebook_mcp/main.py
@@ -234,10 +234,6 @@ if __name__ == "__main__":
     logger.info("Server is starting.....")
     mcp.run(transport='stdio')
 
-# as the cli entry after the "pip install ebook-mcp"
 def cli_entry():
-    import logging
-    logging.info("Starting ebook-mcp server")
-    from mcp.server.fastmcp import FastMCP
-    mcp = FastMCP("ebook-mcp")
+    logger.info("Starting ebook-mcp server")
     mcp.run(transport='stdio')


### PR DESCRIPTION
cli_entry was creating a new empty FastMCP instance instead of using the module-level one that has all tools registered. This allows running the server via

```bash
uvx --from git+https://github.com/onebirdrocks/ebook-mcp.git ebook-mcp
```

Example MCP configuration:

```json
{
  "mcpServers": {
    "ebook": {
      "command": "uvx",
      "args": [
       // 👇can be replaced with "...onebirdrocks/ebook-mcp.git" once merged
        "--from=https://github.com/earshinov/ebook-mcp.git",
        "ebook-mcp"
      ]
    }
  }
}
```